### PR TITLE
Fix README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 Flake8 print plugin
-==================
+===================
 
 Check for Print statements in python files.
 
@@ -29,7 +29,7 @@ Changes
 -------
 
 2.0.1 - 2015-11-21
-````````````````
+``````````````````
 * Add back the decorator to fix the `flake8 --version` call.
 
 2.0 - 2015-11-10
@@ -41,7 +41,7 @@ Changes
 * Added testing for Python 3.3 and 3.5, and different flake8 versions
 
 1.6.1 - 2015-05-22
-````````````````
+``````````````````
 * Fix bug introduced in 1.6.
 
 1.6 - 2015-05-18


### PR DESCRIPTION
PyPI RST renderer is very strict, that's why https://pypi.python.org/pypi/flake8-print looks broken at current.

You can check it with `setup.py`. Before this change:

```sh
$ python setup.py check --metadata --restructuredtext
running check
warning: check: Title underline too short. (line 2)

warning: check: Title underline too short. (line 32)

warning: check: Title underline too short. (line 44)

warning: check: Title underline too short. (line 44)
```

After:

```sh
$ python setup.py check --metadata --restructuredtext
running check
$ echo $?
0
```

After merging this, run `python setup.py register` to fix the appearance on PyPI.