### PR TITLE
Rename entry point to enable plugin codes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     zip_safe=False,
     entry_points={
         'flake8.extension': [
-            'flake8_print = flake8_print:print_usage',
+            'T = flake8_print:print_usage',
         ],
     },
     install_requires=install_requires,


### PR DESCRIPTION
In flake8 v3, plugin codes are enabled automatically based on the plugin entry point name.
https://github.com/PyCQA/flake8/blob/master/src/flake8/plugins/manager.py#L188
https://github.com/PyCQA/flake8/commit/ec2e601cbf9a56c9bee2ee3cc22999c795c1c824
