### PR TITLE
Go back to a simpler time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
   - "2.7"
   - "2.6"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ install:
   - pip install pycodestyle
   - if [[ -n "$FLAKE8_VERSION" ]]; then pip install flake8=="$FLAKE8_VERSION"; fi
   - python setup.py install
-script: "nosetests"
+script: "pytest"

--- a/README.rst
+++ b/README.rst
@@ -28,11 +28,12 @@ available in ``flake8``::
 Changes
 -------
 
-3.0.0 - todo
+3.0.0 - 2017-11-05
 ``````````````````
 * Remove some of the python 2/3 message differentiation.
 * Use an AST rather than a logical line checker with a regex.
-* Still fiddling and trying to restore the multiline lost so far.
+* pprint support.
+* Loss of multiline noqa support, until there is a way to use both the AST and have flake8 provide the noqa lines.
 
 
 2.0.2 - 2016-02-29

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,13 @@ available in ``flake8``::
 Changes
 -------
 
+3.0.0 - todo
+``````````````````
+* Remove some of the python 2/3 message differentiation.
+* Use an AST rather than a logical line checker with a regex.
+* Still fiddling and trying to restore the multiline lost so far.
+
+
 2.0.2 - 2016-02-29
 ``````````````````
 * Fix ReadMe for pipy

--- a/blah.py
+++ b/blah.py
@@ -1,4 +1,0 @@
-print("a"  # noqa\n
-      "b")
-x = 4
-y = 7

--- a/blah.py
+++ b/blah.py
@@ -1,0 +1,4 @@
+print("a"  # noqa\n
+      "b")
+x = 4
+y = 7

--- a/flake8_print.py
+++ b/flake8_print.py
@@ -1,28 +1,96 @@
 """Extension for flake8 that finds usage of print."""
-import re
+import pycodestyle
+import ast
+from six import PY3
 
-__version__ = '2.0.2'
+__version__ = '2.1.2'
 
-CHECKS = [
-    (re.compile(r"(?<![=\s])\s*\bprint\b\s+[^(=]"), 'T001', 'print statement found.'),
-    (re.compile(r"(?<!def\s)\bprint\b\s*\([^)]*\)"), 'T003', 'print function found.'),
-    (re.compile(r"\bprint\b"), 'T101', 'Python 2.x reserved word print used.')
-]
+PRINT_FUNCTION_NAME = "print"
+PPRINT_FUNCTION_NAME = "pprint"
+PRINT_FUNCTION_NAMES = [PRINT_FUNCTION_NAME, PPRINT_FUNCTION_NAME]
+
+VIOLATIONS = {
+    'found': {
+        'print': 'T001 print found.',
+        'pprint': 'T003 pprint found.',
+    },
+    'declared': {
+        'print': 'T101 Python 2.x reserved word print used.',
+        'pprint': 'T103 pprint declared',
+    },
+}
 
 
-def flake8ext(f):
-    """Decorate flake8 extension function."""
-    f.name = 'flake8-print'
-    f.version = __version__
-    return f
+class PrintFinder(ast.NodeVisitor):
+    def __init__(self, *args, **kwargs):
+        super(PrintFinder, self).__init__(*args, **kwargs)
+        self.prints_used = {}
+        self.prints_redefined = {}
+
+    def visit_Print(self, node):
+        """Only exists in python 2."""
+        self.prints_used[(node.lineno, node.col_offset)] = VIOLATIONS["found"][PRINT_FUNCTION_NAME]
+
+    def visit_Call(self, node):
+        is_print_function = getattr(node.func, "id", None) in PRINT_FUNCTION_NAMES
+        is_print_function_attribute = (
+            getattr(getattr(node.func, "value", None), "id", None) in PRINT_FUNCTION_NAMES and getattr(node.func, "attr", None) in PRINT_FUNCTION_NAMES
+        )
+        if is_print_function:
+            self.prints_used[(node.lineno, node.col_offset)] = VIOLATIONS["found"][node.func.id]
+        elif is_print_function_attribute:
+            self.prints_used[(node.lineno, node.col_offset)] = VIOLATIONS["found"][node.func.attr]
+        self.generic_visit(node)
+
+    def visit_FunctionDef(self, node):
+        if node.name in PRINT_FUNCTION_NAMES:
+            self.prints_redefined[(node.lineno, node.col_offset)] = VIOLATIONS["declared"][node.name]
+        for arg in node.args.args:
+            if arg.arg in PRINT_FUNCTION_NAMES:
+                self.prints_redefined[(node.lineno, node.col_offset)] = VIOLATIONS["declared"][arg.arg]
+        if PY3:
+            for arg in node.args.kwonlyargs:
+                if arg.arg in PRINT_FUNCTION_NAMES:
+                    self.prints_redefined[(node.lineno, node.col_offset)] = VIOLATIONS["declared"][arg.arg]
+        self.generic_visit(node)
+
+    def visit_Name(self, node):
+        if node.id == PRINT_FUNCTION_NAME:
+            self.prints_redefined[(node.lineno, node.col_offset)] = VIOLATIONS["declared"][node.id]
+        self.generic_visit(node)
 
 
-@flake8ext
-def print_usage(logical_line, noqa=None):
-    if noqa:
-        return
-    for regexp, code, message in CHECKS:
-        match = regexp.search(logical_line)
-        if match is not None:
-            yield match.start(), '{0} {1}'.format(code, message)
-            return
+class PrintChecker(object):
+    options = None
+    name = 'flake8-print'
+    version = __version__
+
+    def __init__(self, tree, filename):
+        self.tree = tree
+        self.filename = filename
+        self.lines = None
+
+    def load_file(self):
+        if self.filename in ("stdin", "-", None):
+            self.filename = "stdin"
+            self.lines = pycodestyle.stdin_get_value().splitlines(True)
+        else:
+            self.lines = pycodestyle.readlines(self.filename)
+
+        if not self.tree:
+            self.tree = ast.parse("".join(self.lines))
+
+    def run(self):
+        if not self.tree or not self.lines:
+            self.load_file()
+
+        parser = PrintFinder()
+        parser.visit(self.tree)
+        for error, message in parser.prints_used.items():
+            if not pycodestyle.noqa(self.lines[error[0] - 1]):
+                yield (error[0], error[1], message, PrintChecker)
+
+        for error, message in parser.prints_redefined.items():
+            if error not in parser.prints_used:
+                if not pycodestyle.noqa(self.lines[error[0] - 1]):
+                    yield (error[0], error[1], message, PrintChecker)

--- a/flake8_print.py
+++ b/flake8_print.py
@@ -3,7 +3,7 @@ import pycodestyle
 import ast
 from six import PY3
 
-__version__ = '2.1.2'
+__version__ = '3.0.0'
 
 PRINT_FUNCTION_NAME = "print"
 PPRINT_FUNCTION_NAME = "pprint"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-flake8==2.2.3
+flake8==3.4.1
+six==1.10.0
+pycodestyle==2.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,10 @@ def get_long_description():
             descr.append(f.read())
     return '\n\n'.join(descr)
 
-install_requires = ['flake8']
 
-test_requires = ['nose', 'flake8>=1.5', 'pycodestyle']
+install_requires = ['flake8>=1.5', 'six', 'pycodestyle']
+
+test_requires = ['pytest', 'flake8>=1.5', 'pycodestyle']
 
 setup(
     name='flake8-print',
@@ -36,7 +37,7 @@ setup(
     zip_safe=False,
     entry_points={
         'flake8.extension': [
-            'flake8_print = flake8_print:print_usage',
+            'T = flake8_print:PrintChecker',
         ],
     },
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     },
     install_requires=install_requires,
     tests_require=test_requires,
+    setup_requires=['pytest-runner'],
     test_suite="nose.collector",
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
I think I prefer the ast method a bit more for capturing this stuff, even though the noqa usage is lost for multi-line and needs to be on the same line as the print.

I think there's a way to get the parent params to know if noqa is on or not, I need to double check that.