### PR TITLE
Pin the pycodestyle versions to versions supported by flake8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ def get_long_description():
     return '\n\n'.join(descr)
 
 
-install_requires = ['flake8>=1.5', 'six', 'pycodestyle']
+install_requires = ['flake8>=1.5', 'six', 'pycodestyle<2.4.0,>=2.0.0']
 
-test_requires = ['pytest', 'flake8>=1.5', 'pycodestyle']
+test_requires = ['pytest', 'flake8>=1.5', 'pycodestyle<2.4.0,>=2.0.0']
 
 setup(
     name='flake8-print',


### PR DESCRIPTION
`pycodestyle` has some breaking changes in its `2.4.0` version.
The `break_around_binary_operator` attribute has been removed the `pycodestyle` module.

Flake8 specifies these versions  `<2.4.0`,`>=2.0.0` for pycodestyle. 
https://pypi.python.org/pypi/flake8

Flake8-print should too.