### PR TITLE
Fix reading from a closed stdin buffer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,11 @@ available in ``flake8``::
 Changes
 -------
 
+3.1.1 - 2019-03-12
+``````````````````
+
+* Fix reading from stdin when it is closed.
+
 3.1.0 - 2018-02-11
 ``````````````````
 * Add a framework classifier for use in pypi.org

--- a/flake8_print.py
+++ b/flake8_print.py
@@ -3,7 +3,12 @@ import pycodestyle
 import ast
 from six import PY2, PY3
 
-__version__ = '3.1.0'
+try:
+    from flake8.engine import pep8 as stdin_utils
+except ImportError:
+    from flake8 import utils as stdin_utils
+
+__version__ = '3.1.1'
 
 PRINT_FUNCTION_NAME = "print"
 PPRINT_FUNCTION_NAME = "pprint"
@@ -78,7 +83,7 @@ class PrintChecker(object):
     def load_file(self):
         if self.filename in ("stdin", "-", None):
             self.filename = "stdin"
-            self.lines = pycodestyle.stdin_get_value().splitlines(True)
+            self.lines = stdin_utils.stdin_get_value().splitlines(True)
         else:
             self.lines = pycodestyle.readlines(self.filename)
 


### PR DESCRIPTION
**Summary:** Couple of `flake8` plugins rely on [pycodestyle.stdin_get_value](https://github.com/PyCQA/pycodestyle/blob/master/pycodestyle.py#L1762), which does not cache the string, after reading it from stdin and closing the buffer. This means that if there are two plugins using this function - the second plugin relying on this function, cannot read from stdin, because it was closed, and `ValueError: I/O operation on closed file` gets raised.

**Fix:** use [flake8.utils.stdin_get_value](https://github.com/PyCQA/flake8/blob/master/src/flake8/utils.py#L205), which caches the stdin, so that multiple plugins can use it. It is based on [flake8-commas](https://github.com/PyCQA/flake8-commas/blob/master/flake8_commas/_base.py#L10) that does not seem to have this issue.

**Steps to reproduce:**

`requirements.txt`:

```
flake8==3.7.6
flake8-tuple==0.2.13
flake8-print==3.1.0
```

Run:

```
python -m flake8 - < path/to/python/file.py
```

Expected output: lint successfully.
Actual output:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2_2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/__main__.py", line 4, in <module>
    cli.main()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/cli.py", line 18, in main
    app.run(argv)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 394, in run
    self._run(argv)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 382, in _run
    self.run_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/main/application.py", line 301, in run_checks
    self.file_checker_manager.run()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 330, in run
    self.run_serial()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 314, in run_serial
    checker.run_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 608, in run_checks
    self.run_ast_checks()
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8/checker.py", line 504, in run_ast_checks
    for (line_number, offset, text, check) in runner:
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8_tuple.py", line 48, in run
    lines = get_lines(self.filename)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/flake8_tuple.py", line 33, in get_lines
    return pep8.stdin_get_value().splitlines(True)
  File "/Users/julius/Work/workenv/lib/python3.7/site-packages/pycodestyle.py", line 1726, in stdin_get_value
    return TextIOWrapper(sys.stdin.buffer, errors='ignore').read()
ValueError: I/O operation on closed file
```

**Additional comments:**

In my environment this error got triggered in `flake8-print` and `flake8-tuple`. I am simultaneously doing a similar fix to `flake8-tuple` as well. However, there must be a third plugin that uses `pycodestyle.stdin_get_value` first time. I will investigate and do a similar fix as well.

I bumped version up as it would be great to release this fix quickly - it would save my eyes from emacs+flycheck blowing up with an error taking half the buffer on every file save. :)

Let me know if I can improve this to expedite the release.

Thank you.