### PR TITLE
fix issue #40 and #41

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Error codes
 Changes
 -------
 
+##### 3.1.4 - 2019-1-11
+
+* Fix bug introduced in 3.1.3
+
 ##### 3.1.3 - 2019-31-10
 
 * Swapped back from poetry to setup.py :(....python ecosystem issues....

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Changes
 ##### 3.1.4 - 2019-1-11
 
 * Fix bug introduced in 3.1.3
+* Support for `nopep8` comments
 
 ##### 3.1.3 - 2019-31-10
 

--- a/flake8_print.py
+++ b/flake8_print.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from flake8 import utils as stdin_utils
 
-__version__ = "3.1.3"
+__version__ = "3.1.4"
 
 PRINT_FUNCTION_NAME = "print"
 PPRINT_FUNCTION_NAME = "pprint"
@@ -99,12 +99,12 @@ class PrintChecker(object):
                 if error in errors_seen:
                     continue
 
+                errors_seen.add(error)
                 code = message.split(' ', 1)[0]
                 line = self.lines[error[0] - 1]
                 line_has_noqa = bool(pycodestyle.noqa(line))
 
-                if line_has_noqa is True and code in line:
+                if line_has_noqa is True and (code in line or "nopep8" in line):
                     continue
 
-                errors_seen.add(error)
                 yield (error[0], error[1], message, PrintChecker)

--- a/test_linter.py
+++ b/test_linter.py
@@ -67,8 +67,12 @@ class TestNoQA(object):
         result = check_code_for_print_statements("print(4)  # noqa")
         assert result == list()
 
+    def test_skips_nopep8(self):
+        result = check_code_for_print_statements("print(1)  # nopep8")
+        assert result == list()
+
     def test_skips_noqa__with_specific_error_code(self):
-        result = check_code_for_print_statements("print(4)  # noqa: T001")
+        result = check_code_for_print_statements("print(1)  # noqa: T001")
         assert result == list()
 
     @pytest.mark.skip(reason="not supported by pycodestyle ast checks")


### PR DESCRIPTION
Clearly the test aren't 100% reliable or `test_skips_noqa__with_specific_error_code` would have failed. I'll have to rewrite them before the next release.